### PR TITLE
Add near matches to field candidates for lineage template

### DIFF
--- a/src/main/java/no/ssb/dapla/dataset/doc/builder/LineageBuilder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/builder/LineageBuilder.java
@@ -5,7 +5,7 @@ import no.ssb.dapla.dataset.doc.model.lineage.Instance;
 import no.ssb.dapla.dataset.doc.model.lineage.Record;
 import no.ssb.dapla.dataset.doc.model.lineage.Source;
 import no.ssb.dapla.dataset.doc.template.SchemaToLineageTemplate;
-import no.ssb.dapla.dataset.doc.model.lineage.SchemaWithPath;
+import no.ssb.dapla.dataset.doc.traverse.SchemaWithPath;
 import org.apache.avro.Schema;
 
 import java.util.ArrayList;

--- a/src/main/java/no/ssb/dapla/dataset/doc/builder/LineageBuilder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/builder/LineageBuilder.java
@@ -43,6 +43,7 @@ public class LineageBuilder {
         private String type;
         private long version;
         private float confidence;
+        private float matchScore;
         private List<String> fieldCandidates;
 
         public SourceBuilder field(String field) {
@@ -75,9 +76,15 @@ public class LineageBuilder {
             return this;
         }
 
+        public SourceBuilder matchScore(float matchScore) {
+            this.matchScore = matchScore;
+            return this;
+        }
+
         public Source build() {
             Source source = new Source(field, path, version);
             source.setConfidence(confidence);
+            source.setMatchScore(matchScore);
             source.setType(type);
             source.addFieldCandidates(fieldCandidates);
             return source;
@@ -155,6 +162,11 @@ public class LineageBuilder {
 
         public InstanceVariableBuilder addSource(Source source) {
             instance.addSource(source);
+            return this;
+        }
+
+        public InstanceVariableBuilder addTypeCandidates(Collection<String> typeCandidates) {
+            instance.addTypeCandidates(typeCandidates);
             return this;
         }
 

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
@@ -2,11 +2,13 @@ package no.ssb.dapla.dataset.doc.model.lineage;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@JsonPropertyOrder({ "name", "type", "type_candidates", "confidence", "fields" })
 public class Field {
 
     @JsonProperty

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
@@ -15,6 +15,10 @@ public class Field {
     @JsonProperty
     protected String type;
 
+    @JsonProperty("type_candidates")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<String> typeCandidates = new ArrayList<>();
+
     @JsonProperty
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Float confidence;
@@ -58,4 +62,9 @@ public class Field {
     public void setType(String type) {
         this.type = type;
     }
+
+    public void addTypeCandidates(Collection<String> fields) {
+        typeCandidates.addAll(fields);
+    }
+
 }

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Field.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class Field {
 
     @JsonProperty
-    String name;
+    protected String name;
 
     @JsonProperty
     protected String type;

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/FieldFinder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/FieldFinder.java
@@ -1,15 +1,106 @@
 package no.ssb.dapla.dataset.doc.model.lineage;
 
 import no.ssb.avro.convert.core.SchemaBuddy;
-import no.ssb.dapla.dataset.doc.builder.LineageBuilder;
+import no.ssb.dapla.dataset.doc.traverse.ParentAware;
+import no.ssb.dapla.dataset.doc.traverse.PathTraverse;
 import no.ssb.dapla.dataset.doc.traverse.SchemaTraverse;
+import no.ssb.dapla.dataset.doc.traverse.TraverseField;
 import org.apache.avro.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class FieldFinder extends SchemaTraverse<Record> {
+public class FieldFinder extends SchemaTraverse<FieldFinder.Record> {
+
+    static class Record implements TraverseField<FieldFinder.Record>, ParentAware {
+        final Record parent;
+        final String name;
+        private final List<Record> children = new ArrayList<>();
+        private final List<Field> fields = new ArrayList<>();
+
+        public Record(Record parent, String name) {
+            this.parent = parent;
+            this.name = name;
+        }
+
+        @Override
+        public ParentAware getParent() {
+            return parent;
+        }
+
+        @Override
+        public void addChild(Record child) {
+            children.add(child);
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        public List<Record> getChildren() {
+            return children;
+        }
+
+        public String getPath() {
+            PathTraverse<Record> pathTraverse = new PathTraverse<>(this);
+            return pathTraverse.getPath("spark_schema");
+        }
+
+        public void addField(Field field) {
+            fields.add(field);
+        }
+
+        public List<Field> find(String name) {
+            return fields.stream()
+                    .filter(i -> i.isMatch(name))
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    static class Field {
+        final String name;
+
+        public String getPath() {
+            return path;
+        }
+
+        final String path;
+
+        public boolean isMatch(String name) {
+            return name.equals(this.name);
+        }
+
+//        public boolean checkPartialMatchAndSetConfidence(String name) {
+//            if (confidence != null) {
+//                System.out.println("Confidence should not be set, was:" + confidence);
+////            throw new IllegalStateException("Confidence should not be set, was:" + confidence);
+//            }
+//            float existingConfidence = confidence != null ? confidence : 1.0F;
+//            if (this.name.equals(name)) {
+//                setConfidence(existingConfidence);
+//                return true;
+//            }
+//            if (this.name.contains(name)) {
+//                setConfidence(existingConfidence * (name.length() / (float) this.name.length()));
+//                return true;
+//            }
+//            if (name.contains(this.name)) {
+//                setConfidence(existingConfidence * (this.name.length() / (float) name.length()));
+//                return true;
+//            }
+//            return false;
+//        }
+
+
+        public Field(String name, String path) {
+            this.name = name;
+            this.path = path;
+        }
+    }
+
     final SchemaBuddy schemaBuddy;
     final Record root;
 
@@ -19,16 +110,16 @@ public class FieldFinder extends SchemaTraverse<Record> {
     }
 
     public List<String> getPaths(String field) {
-        return find(field).stream().map(Instance::getPath).collect(Collectors.toList());
+        return find(field).stream().map(Field::getPath).collect(Collectors.toList());
     }
 
-    public List<Instance> find(String field) {
-        List<Instance> result = new ArrayList<>();
+    public List<Field> find(String field) {
+        List<Field> result = new ArrayList<>();
         search(field, root, result);
         return result;
     }
 
-    private void search(String name, Record parent, List<Instance> result) {
+    private void search(String name, Record parent, List<Field> result) {
         result.addAll(parent.find(name));
         for (Record child : parent.getChildren()) {
             search(name, child, result);
@@ -36,21 +127,15 @@ public class FieldFinder extends SchemaTraverse<Record> {
     }
 
     @Override
-    protected Record createChild(SchemaBuddy schemaBuddy, Record parent) {
-        return LineageBuilder.createLogicalRecordBuilder()
-                .parent(parent)
-                .name(schemaBuddy.getName())
-                .build();
+    protected FieldFinder.Record createChild(SchemaBuddy schemaBuddy, FieldFinder.Record parent) {
+        return new FieldFinder.Record(parent, schemaBuddy.getName());
     }
 
     @Override
     protected void processField(SchemaBuddy schemaBuddy, Record parent) {
-        Instance instance = LineageBuilder.createInstanceVariableBuilder()
-                .name(schemaBuddy.getName())
-                .build();
         // TODO: Find a better to deal with "spark_schema" root
         String path = parent.getPath().equals("spark_schema") ? "" : parent.getPath() + ".";
-        instance.setPath(path + schemaBuddy.getName());
-        parent.addInstanceVariable(instance);
+        Field field = new Field(schemaBuddy.getName(), path + schemaBuddy.getName());
+        parent.addField(field);
     }
 }

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Record.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Record.java
@@ -2,12 +2,7 @@ package no.ssb.dapla.dataset.doc.model.lineage;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import no.ssb.dapla.dataset.doc.traverse.ParentAware;
-import no.ssb.dapla.dataset.doc.traverse.PathTraverse;
 import no.ssb.dapla.dataset.doc.traverse.TraverseField;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class Record extends Field implements TraverseField<Record>, ParentAware {
 
@@ -17,45 +12,20 @@ public class Record extends Field implements TraverseField<Record>, ParentAware 
     }
 
     @JsonIgnore
-    private final List<Record> children = new ArrayList<>();
-
-    @JsonIgnore
-    private final List<Instance> instances = new ArrayList<>();
-
-    @JsonIgnore
     private Record parent;
-
-    @JsonIgnore
-    public List<Record> getChildren() {
-        return children;
-    }
 
     @Override
     public ParentAware getParent() {
         return parent;
     }
 
-    @JsonIgnore
-    public String getPath() {
-        PathTraverse<Record> pathTraverse = new PathTraverse<>(this);
-        return pathTraverse.getPath("spark_schema");
-    }
-
     @Override
     public void addChild(Record record) {
-        children.add(record);
         fields.add(record);
-    }
-
-    public List<Instance> find(String name) {
-        return instances.stream()
-                .filter(i -> i.getName().equals(name))
-                .collect(Collectors.toList());
     }
 
     public void addInstanceVariable(Instance instance) {
         fields.add(instance);
-        instances.add(instance);
     }
 
     public void setParent(Record parent) {

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SchemaWithPath.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SchemaWithPath.java
@@ -22,14 +22,14 @@ public class SchemaWithPath {
     }
 
     public Source getSource(String name) {
-        List<Instance> instances = fieldFinder.find(name);
+        List<FieldFinder.Field> instances = fieldFinder.find(name);
         if (instances.isEmpty()) {
             return null;
         }
         int fieldCount = instances.size();
-        String paths = instances.stream().map(Instance::getPath).collect(Collectors.joining(","));
+        String paths = instances.stream().map(FieldFinder.Field::getPath).collect(Collectors.joining(","));
         float confidence = 0.9F / fieldCount; // TODO: calculate confidence based on if we have one field or more matches
-        List<String> fields = fieldCount > 1 ? instances.stream().map(Instance::getPath).collect(Collectors.toList()) : Collections.emptyList();
+        List<String> fields = fieldCount > 1 ? instances.stream().map(FieldFinder.Field::getPath).collect(Collectors.toList()) : Collections.emptyList();
         return LineageBuilder.crateSourceBuilder()
                 .field(fieldCount == 1 ? paths : "")
                 .fieldCandidates(fields)

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Source.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Source.java
@@ -29,7 +29,14 @@ public class Source {
     private float confidence;
 
     @JsonIgnore
+    private float matchScore;
+
+    @JsonIgnore
     private String type;
+
+    public long getVersion() {
+        return version;
+    }
 
     public Source(String field, String path, long version) {
         this.field = field;
@@ -70,5 +77,13 @@ public class Source {
 
     public List<String> getFieldCandidates() {
         return fieldCandidates;
+    }
+
+    public float getMatchScore() {
+        return matchScore;
+    }
+
+    public void setMatchScore(float matchScore) {
+        this.matchScore = matchScore;
     }
 }

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Source.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/Source.java
@@ -40,6 +40,10 @@ public class Source {
     public Source() {
     }
 
+    public String getField() {
+        return field;
+    }
+
     public float getConfidence() {
         return confidence;
     }
@@ -58,5 +62,13 @@ public class Source {
 
     public void addFieldCandidates(Collection<String> fields) {
         fieldCandidates.addAll(fields);
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public List<String> getFieldCandidates() {
+        return fieldCandidates;
     }
 }

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
@@ -1,15 +1,19 @@
 package no.ssb.dapla.dataset.doc.model.lineage;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class SourceConfidence {
     private final Collection<Source> sources;
 
+    private final float matchScore;
+
     public SourceConfidence(Collection<Source> sources) {
         this.sources = sources;
+
+        matchScore = sources.stream().map(Source::getMatchScore).reduce((a, b) -> a * b).orElse(0F);
     }
 
     public float getAverageConfidenceOfSources() {
@@ -18,9 +22,17 @@ public class SourceConfidence {
         return sum != 0F ? sum / sources.size() : 0F;
     }
 
-    public String getFieldType() {
-        Set<String> types = sources.stream().map(Source::getType).collect(Collectors.toSet());
-        return String.join(",", types);
+    public Collection<String> getTypeCandidates() {
+        if (matchScore < 1.0F) {
+            return sources.stream().map(Source::getType).collect(Collectors.toSet());
+        }
+        return Collections.emptyList();
+    }
 
+    public String getFieldType() {
+        if (matchScore >= 1.0f) {
+            return "inherited";
+        }
+        return "";
     }
 }

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
@@ -1,0 +1,26 @@
+package no.ssb.dapla.dataset.doc.model.lineage;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SourceConfidence {
+    private final Collection<Source> sources;
+
+    public SourceConfidence(Collection<Source> sources) {
+        this.sources = sources;
+    }
+
+    public float getAverageConfidenceOfSources() {
+        Optional<Float> confidence = sources.stream().map(Source::getConfidence).reduce(Float::sum);
+        float sum = confidence.orElse(0F);
+        return sum != 0F ? sum / sources.size() : 0F;
+    }
+
+    public String getFieldType() {
+        Set<String> types = sources.stream().map(Source::getType).collect(Collectors.toSet());
+        return String.join(",", types);
+
+    }
+}

--- a/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/model/lineage/SourceConfidence.java
@@ -1,5 +1,6 @@
 package no.ssb.dapla.dataset.doc.model.lineage;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -24,7 +25,9 @@ public class SourceConfidence {
 
     public Collection<String> getTypeCandidates() {
         if (matchScore < 1.0F) {
-            return sources.stream().map(Source::getType).collect(Collectors.toSet());
+//            return sources.stream().map(Source::getType).collect(Collectors.toSet());
+            // for now we have no way to now so we returned the two possibilities
+            return Arrays.asList("created", "derived");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
@@ -11,6 +11,7 @@ import no.ssb.dapla.dataset.doc.builder.LineageBuilder;
 import no.ssb.dapla.dataset.doc.model.lineage.Dataset;
 import no.ssb.dapla.dataset.doc.model.lineage.Instance;
 import no.ssb.dapla.dataset.doc.model.lineage.Record;
+import no.ssb.dapla.dataset.doc.model.lineage.SourceConfidence;
 import no.ssb.dapla.dataset.doc.traverse.SchemaWithPath;
 import no.ssb.dapla.dataset.doc.model.lineage.Source;
 import no.ssb.dapla.dataset.doc.traverse.SchemaTraverse;
@@ -20,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class SchemaToLineageTemplate extends SchemaTraverse<Record> {
@@ -69,15 +69,12 @@ public class SchemaToLineageTemplate extends SchemaTraverse<Record> {
     private Instance getInstanceVariable(String name) {
         Collection<Source> sources = findSources(name);
 
-        Optional<Float> confidence = sources.stream().map(Source::getConfidence).reduce(Float::sum);
-        float sum = confidence.orElse(0F);
-        float result = sum != 0F ? sum / sources.size() : 0F;
-        String type = sum != 0F ? "inherited" : "derived/created";
+        SourceConfidence sourceConfidence = new SourceConfidence(sources);
 
         return LineageBuilder.createInstanceVariableBuilder()
                 .name(name)
-                .confidence(result) // TODO calculate when finding from source schema
-                .type(type) // For now we can't find what is derived
+                .confidence(sourceConfidence.getAverageConfidenceOfSources())
+                .type(sourceConfidence.getFieldType())
                 .addSources(sources)
                 .build();
     }

--- a/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
@@ -11,7 +11,7 @@ import no.ssb.dapla.dataset.doc.builder.LineageBuilder;
 import no.ssb.dapla.dataset.doc.model.lineage.Dataset;
 import no.ssb.dapla.dataset.doc.model.lineage.Instance;
 import no.ssb.dapla.dataset.doc.model.lineage.Record;
-import no.ssb.dapla.dataset.doc.model.lineage.SchemaWithPath;
+import no.ssb.dapla.dataset.doc.traverse.SchemaWithPath;
 import no.ssb.dapla.dataset.doc.model.lineage.Source;
 import no.ssb.dapla.dataset.doc.traverse.SchemaTraverse;
 import org.apache.avro.Schema;

--- a/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplate.java
@@ -75,6 +75,7 @@ public class SchemaToLineageTemplate extends SchemaTraverse<Record> {
                 .name(name)
                 .confidence(sourceConfidence.getAverageConfidenceOfSources())
                 .type(sourceConfidence.getFieldType())
+                .addTypeCandidates(sourceConfidence.getTypeCandidates())
                 .addSources(sources)
                 .build();
     }

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
@@ -109,10 +109,6 @@ public class FieldFinder extends SchemaTraverse<FieldFinder.Record> {
         root = traverse(schemaBuddy);
     }
 
-    public List<String> getPaths(String field) {
-        return find(field).stream().map(Field::getPath).collect(Collectors.toList());
-    }
-
     public List<Field> find(String field) {
         List<Field> result = new ArrayList<>();
         search(field, root, result);

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
@@ -9,13 +9,13 @@ import java.util.stream.Collectors;
 
 public class FieldFinder extends SchemaTraverse<FieldFinder.Record> {
 
-    static class Record implements TraverseField<FieldFinder.Record>, ParentAware {
+    protected static class Record implements TraverseField<FieldFinder.Record>, ParentAware {
         final Record parent;
         final String name;
         private final List<Record> children = new ArrayList<>();
         private final List<Field> fields = new ArrayList<>();
 
-        public Record(Record parent, String name) {
+        private Record(Record parent, String name) {
             this.parent = parent;
             this.name = name;
         }
@@ -59,13 +59,16 @@ public class FieldFinder extends SchemaTraverse<FieldFinder.Record> {
                     .filter(i -> i.isNearMatch(name))
                     .collect(Collectors.toList());
         }
-
-
     }
 
     static class Field {
         final String name;
         final String path;
+
+        public Field(String name, String path) {
+            this.name = name;
+            this.path = path;
+        }
 
         private float matchScore = 1.0F;
 
@@ -96,11 +99,6 @@ public class FieldFinder extends SchemaTraverse<FieldFinder.Record> {
             return false;
         }
 
-
-        public Field(String name, String path) {
-            this.name = name;
-            this.path = path;
-        }
     }
 
     final SchemaBuddy schemaBuddy;

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/FieldFinder.java
@@ -1,10 +1,6 @@
-package no.ssb.dapla.dataset.doc.model.lineage;
+package no.ssb.dapla.dataset.doc.traverse;
 
 import no.ssb.avro.convert.core.SchemaBuddy;
-import no.ssb.dapla.dataset.doc.traverse.ParentAware;
-import no.ssb.dapla.dataset.doc.traverse.PathTraverse;
-import no.ssb.dapla.dataset.doc.traverse.SchemaTraverse;
-import no.ssb.dapla.dataset.doc.traverse.TraverseField;
 import org.apache.avro.Schema;
 
 import java.util.ArrayList;

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class SchemaWithPath {
+    static final float REQUIRED_MATCH_SCORE = 0.5F;// 1.0F is full match
+
     final Schema schema;
     final String path;
     final long version;
@@ -34,17 +36,25 @@ public class SchemaWithPath {
         if (fields.isEmpty()) {
             return null;
         }
-        int fieldCount = fields.size();
-        String paths = fields.stream().map(FieldFinder.Field::getPath).collect(Collectors.joining(","));
-        Float matchScore = fields.stream().map(FieldFinder.Field::getMatchScore).reduce((aFloat, aFloat2) -> aFloat * aFloat2).orElse(0F);
+        List<FieldFinder.Field> validMatches = fields.stream()
+                .filter(field -> field.getMatchScore() > REQUIRED_MATCH_SCORE)
+                .collect(Collectors.toList());
+        if (validMatches.isEmpty()) {
+            return null;
+        }
+
+        int fieldCount = validMatches.size();
+        String paths = validMatches.stream().map(FieldFinder.Field::getPath).collect(Collectors.joining(","));
+        float matchScore = validMatches.stream().map(FieldFinder.Field::getMatchScore).reduce((a, b) -> a * b).orElse(0F);
         float confidence = (0.9F / fieldCount) * matchScore; // TODO: calculate confidence based on if we have one field or more matches
-        List<String> fieldCandidates = getFieldCandidates(fields, fieldCount, matchScore);
+        List<String> fieldCandidates = getFieldCandidates(validMatches, fieldCount, matchScore);
         return LineageBuilder.crateSourceBuilder()
                 .field(fieldCount == 1 && matchScore == 1.0F ? paths : "")
                 .fieldCandidates(fieldCandidates)
                 .path(path)
                 .version(version)
                 .confidence(confidence)
+                .type(matchScore == 1.0f ? "inherited" : "derived/created")
                 .build();
     }
 

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
@@ -1,6 +1,7 @@
-package no.ssb.dapla.dataset.doc.model.lineage;
+package no.ssb.dapla.dataset.doc.traverse;
 
 import no.ssb.dapla.dataset.doc.builder.LineageBuilder;
+import no.ssb.dapla.dataset.doc.model.lineage.Source;
 import org.apache.avro.Schema;
 
 import java.util.Collections;

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
@@ -49,7 +49,7 @@ public class SchemaWithPath {
         int fieldCount = validMatches.size();
         String paths = validMatches.stream().map(FieldFinder.Field::getPath).collect(Collectors.joining(","));
         float matchScore = validMatches.stream().map(FieldFinder.Field::getMatchScore).reduce((a, b) -> a * b).orElse(0F);
-        float confidence = (MAX_AUTO_MATCH_CONFIDENCE / fieldCount) * matchScore; // TODO: calculate confidence based on if we have one field or more matches
+        float confidence = (MAX_AUTO_MATCH_CONFIDENCE / fieldCount) * matchScore;
         List<String> fieldCandidates = getFieldCandidates(validMatches, fieldCount, matchScore);
         return LineageBuilder.crateSourceBuilder()
                 .field(fieldCount == 1 && matchScore == FULL_MATCH_SCORE ? paths : "")
@@ -58,7 +58,6 @@ public class SchemaWithPath {
                 .version(version)
                 .confidence(confidence)
                 .matchScore(matchScore)
-                .type(matchScore == FULL_MATCH_SCORE ? "inherited" : "derived/created")
                 .build();
     }
 

--- a/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPath.java
@@ -25,12 +25,12 @@ public class SchemaWithPath {
     public Source getSource(String name) {
         List<FieldFinder.Field> fields = fieldFinder.find(name);
         if (fields.isEmpty()) {
-            return getSource(fieldFinder.findNearMatches(name));
+            return findSource(fieldFinder.findNearMatches(name));
         }
-        return getSource(fields);
+        return findSource(fields);
     }
 
-    private Source getSource(List<FieldFinder.Field> fields) {
+    private Source findSource(List<FieldFinder.Field> fields) {
         if (fields.isEmpty()) {
             return null;
         }
@@ -49,7 +49,7 @@ public class SchemaWithPath {
     }
 
     private List<String> getFieldCandidates(List<FieldFinder.Field> fields, int fieldCount, Float matchScore) {
-        if (fieldCount > 1 || matchScore < 1.0F ) {
+        if (fieldCount > 1 || matchScore < 1.0F) {
             return fields.stream().map(FieldFinder.Field::getPath).collect(Collectors.toList());
         }
         return Collections.emptyList();

--- a/src/test/java/no/ssb/dapla/dataset/doc/model/lineage/FieldFinderTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/model/lineage/FieldFinderTest.java
@@ -46,13 +46,13 @@ class FieldFinderTest {
 
         FieldFinder fieldFinder = new FieldFinder(schema);
 
-        List<Instance> instances = fieldFinder.find("organisasjonsnummer");
-        List<String> paths = instances.stream().map(Instance::getPath).collect(Collectors.toList());
+        List<FieldFinder.Field> instances = fieldFinder.find("organisasjonsnummer");
+        List<String> paths = instances.stream().map(FieldFinder.Field::getPath).collect(Collectors.toList());
         assertThat(paths.size()).isEqualTo(12);
 
-        fieldFinder.find("organisasjonsnummer").stream().map(Instance::getPath).forEach(System.out::println);
+        fieldFinder.find("organisasjonsnummer").stream().map(FieldFinder.Field::getPath).forEach(System.out::println);
         System.out.println("----------------------");
-        fieldFinder.find("personidentifikator").stream().map(Instance::getPath).forEach(System.out::println);
+        fieldFinder.find("personidentifikator").stream().map(FieldFinder.Field::getPath).forEach(System.out::println);
     }
 
 }

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
@@ -9,7 +9,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 import no.ssb.dapla.dataset.doc.builder.LineageBuilder;
 import no.ssb.dapla.dataset.doc.model.lineage.Dataset;
-import no.ssb.dapla.dataset.doc.model.lineage.SchemaWithPath;
+import no.ssb.dapla.dataset.doc.traverse.SchemaWithPath;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.json.JSONException;

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
@@ -166,7 +166,6 @@ class SchemaToLineageTemplateTest {
         // Check that we can parse json
         Dataset root = new ObjectMapper().readValue(jsonString, Dataset.class);
         String jsonStringForDataSet = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(root);
-        System.out.println(jsonStringForDataSet);
     }
 
     @Test

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
@@ -122,7 +122,7 @@ class SchemaToLineageTemplateTest {
     }
 
     @Test
-    void testJoinTwoSourcesFromComplexSchema() throws JsonProcessingException {
+    void testJoinTwoSourcesFromComplexSchema() throws JsonProcessingException, JSONException {
         Schema inputSchemaSkatt = SchemaBuilder
                 .record("spark_schema").namespace("no.ssb.dataset")
                 .fields()
@@ -161,7 +161,10 @@ class SchemaToLineageTemplateTest {
                         .build();
 
         String jsonString = schemaToTemplate.generateTemplateAsJsonString();
-        System.out.println(jsonString);
+
+        String expected = TestUtils.load("testdata/lineage/lineage-partial-match.json");
+        assertThat(jsonString).isEqualTo(expected);
+        JSONAssert.assertEquals(expected, jsonString, true);
 
         // Check that we can parse json
         Dataset root = new ObjectMapper().readValue(jsonString, Dataset.class);

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToLineageTemplateTest.java
@@ -161,6 +161,7 @@ class SchemaToLineageTemplateTest {
                         .build();
 
         String jsonString = schemaToTemplate.generateTemplateAsJsonString();
+        System.out.println(jsonString);
 
         // Check that we can parse json
         Dataset root = new ObjectMapper().readValue(jsonString, Dataset.class);
@@ -217,10 +218,6 @@ class SchemaToLineageTemplateTest {
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String jsonOutput = gson.toJson(new JsonParser().parse(jsonString));
-
-        // Check that we can parse json
-        Dataset root = new ObjectMapper().readValue(jsonOutput, Dataset.class);
-        assertThat(root.getRoot().getPath()).isEqualTo("spark_schema");
 
         String expected = TestUtils.load("testdata/lineage/checkSkattRawToKontoFields.json");
         assertThat(jsonOutput).isEqualTo(expected);

--- a/src/test/java/no/ssb/dapla/dataset/doc/traverse/FieldFinderTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/traverse/FieldFinderTest.java
@@ -1,4 +1,4 @@
-package no.ssb.dapla.dataset.doc.model.lineage;
+package no.ssb.dapla.dataset.doc.traverse;
 
 import no.ssb.dapla.dataset.doc.template.TestUtils;
 import org.apache.avro.Schema;

--- a/src/test/java/no/ssb/dapla/dataset/doc/traverse/FieldFinderTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/traverse/FieldFinderTest.java
@@ -5,15 +5,16 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class FieldFinderTest {
 
-    Schema inputSchemaSkatt = SchemaBuilder
+    final Schema inputSchemaSkatt = SchemaBuilder
             .record("spark_schema").namespace("no.ssb.dataset")
             .fields()
             .name("fnr").type().stringType().noDefault()
@@ -24,20 +25,33 @@ class FieldFinderTest {
                             .endRecord())
             .endRecord();
 
-    @Test
-    void find() {
-        FieldFinder fieldFinder = new FieldFinder(inputSchemaSkatt);
+    final FieldFinder fieldFinder = new FieldFinder(inputSchemaSkatt);
 
-        List<String> paths = fieldFinder.getPaths("innskudd");
-        assertThat(paths).isEqualTo(Collections.singletonList("konto.innskudd"));
+    void checkField(Function<String, List<FieldFinder.Field>> func, String name, Consumer<FieldFinder.Field> check) {
+        List<FieldFinder.Field> fields = func.apply(name);
+        assert fields.size() == 1;
+        check.accept(fields.get(0));
     }
 
     @Test
-    void find2FindFnr() {
-        FieldFinder fieldFinder = new FieldFinder(inputSchemaSkatt);
+    void checkThatWeCanFindFields() {
+        checkField(fieldFinder::find, "fnr", f -> {
+            assertThat(f.path).isEqualTo("fnr");
+            assertThat(f.getMatchScore()).isEqualTo(1.0F);
+        });
 
-        List<String> paths = fieldFinder.getPaths("fnr");
-        assertThat(paths).isEqualTo(Collections.singletonList("fnr"));
+        checkField(fieldFinder::find, "innskudd", f -> {
+            assertThat(f.path).isEqualTo("konto.innskudd");
+            assertThat(f.getMatchScore()).isEqualTo(1.0F);
+        });
+    }
+
+    @Test
+    void checkThatWeCanFindNearFields() {
+        checkField(fieldFinder::findNearMatches, "sum_innskudd", f -> {
+            assertThat(f.path).isEqualTo("konto.innskudd");
+            assertThat(f.getMatchScore()).isLessThan(1.0F);
+        });
     }
 
     @Test

--- a/src/test/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPathTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/traverse/SchemaWithPathTest.java
@@ -1,0 +1,69 @@
+package no.ssb.dapla.dataset.doc.traverse;
+
+import no.ssb.dapla.dataset.doc.model.lineage.Source;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaWithPathTest {
+
+    final Schema inputSchemaSkatt = SchemaBuilder
+            .record("spark_schema").namespace("no.ssb.dataset")
+            .fields()
+            .name("fnr").type().stringType().noDefault()
+            .name("konto").type().optional().type(
+                    SchemaBuilder.record("konto")
+                            .fields()
+                            .name("innskudd").type().stringType().noDefault()
+                            .endRecord())
+            .endRecord();
+
+    SchemaWithPath schemaWithPath = new SchemaWithPath(inputSchemaSkatt, "/path/to/data", 123);
+
+    @Test
+    void checkNoMatch() {
+        Source s = schemaWithPath.getSource("bla");
+        assert s == null;
+    }
+
+    @Test
+    void checkThatMatches() {
+        Source s = schemaWithPath.getSource("innskudd");
+        assertThat(s.getField()).isEqualTo("konto.innskudd");
+        assertThat(s.getFieldCandidates()).hasSize(0);
+        assertThat(s.getConfidence()).isEqualTo(0.9F);
+        assertThat(s.getType()).isEqualTo("inherited");
+    }
+
+    @Test
+    void checkThatHavePartialMatch() {
+        Source s = schemaWithPath.getSource("sum_innskudd");
+        assertThat(s.getField()).isEqualTo("");
+        assertThat(s.getFieldCandidates()).hasSize(1);
+        assertThat(s.getFieldCandidates().get(0)).isEqualTo("konto.innskudd");
+        assertThat(s.getConfidence()).isLessThan(0.9F);
+        assertThat(s.getConfidence()).isGreaterThan(0.5F);
+        assertThat(s.getType()).isEqualTo("derived/created");
+    }
+
+    @Test
+    void checkThatHavePartialMatchWithMinimumChars() {
+        Source s = schemaWithPath.getSource("innsk");
+        assertThat(s.getField()).isEqualTo("");
+        assertThat(s.getFieldCandidates()).hasSize(1);
+        assertThat(s.getFieldCandidates().get(0)).isEqualTo("konto.innskudd");
+        assertThat(s.getConfidence()).isLessThan(0.6F);
+        assertThat(s.getConfidence()).isGreaterThan(0.5F);
+        assertThat(s.getType()).isEqualTo("derived/created");
+    }
+
+    @Test
+    void checkThatShouldNotMatch3LettersOrLess() {
+        Source s = schemaWithPath.getSource("inns");
+        assertThat(s).isNull();
+    }
+
+}

--- a/src/test/resources/testdata/lineage/lineage-partial-match.json
+++ b/src/test/resources/testdata/lineage/lineage-partial-match.json
@@ -1,0 +1,56 @@
+{
+  "lineage": {
+    "name": "spark_schema",
+    "type": "structure",
+    "fields": [
+      {
+        "name": "fnr",
+        "type": "inherited",
+        "confidence": 0.9,
+        "sources": [
+          {
+            "field": "fnr",
+            "path": "/kilde/skatt/konto/innskudd",
+            "version": 123456789
+          },
+          {
+            "field": "fnr",
+            "path": "/kilde/freg/alder",
+            "version": 123456789
+          }
+        ]
+      },
+      {
+        "name": "sum_innskudd",
+        "type": "",
+        "type_candidates": [
+          "created",
+          "derived"
+        ],
+        "confidence": 0.6,
+        "sources": [
+          {
+            "field_candidates": [
+              "konto.innskudd"
+            ],
+            "field": "",
+            "path": "/kilde/skatt/konto/innskudd",
+            "version": 123456789
+          }
+        ]
+      },
+      {
+        "name": "alder",
+        "type": "inherited",
+        "confidence": 0.9,
+        "sources": [
+          {
+            "field": "person.alder",
+            "path": "/kilde/freg/alder",
+            "version": 123456789
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
If we have a partial match we get `field_candidates` and `type_candidates` 
Inn the example under `sum_innskudd` is a partial match of `innskudd`
```
      {
        "name": "sum_innskudd",
        "type": "",
        "type_candidates": [
          "created",
          "derived"
        ],
        "confidence": 0.6,
        "sources": [
          {
            "field_candidates": [
              "konto.innskudd"
            ],
            "field": "",
            "path": "/kilde/skatt/konto/innskudd",
            "version": 123456789
          }
        ]
      }

```
