### PR TITLE
Validate template against chema

### DIFF
--- a/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToTemplate.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/SchemaToTemplate.java
@@ -50,6 +50,10 @@ public class SchemaToTemplate extends SchemaTraverse<Record> {
         return this;
     }
 
+    public ValidateResult validate(String existingDocTemplate) {
+        return new TemplateValidator(existingDocTemplate).validate(schema);
+    }
+
     public SchemaToTemplate withLogicalRecordFilterFilter(String... ignoreFields) {
         if (!logicalRecordFilter.isEmpty()) {
             throw new IllegalStateException("LogicalRecord already contains " + ignoreFields + ". use addLogicalRecordFilter to add");

--- a/src/main/java/no/ssb/dapla/dataset/doc/template/TemplateValidator.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/TemplateValidator.java
@@ -1,0 +1,52 @@
+package no.ssb.dapla.dataset.doc.template;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.ssb.avro.convert.core.SchemaBuddy;
+import no.ssb.dapla.dataset.doc.model.simple.Instance;
+import no.ssb.dapla.dataset.doc.model.simple.Record;
+import org.apache.avro.Schema;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TemplateValidator {
+
+    private final Record root;
+
+    public TemplateValidator(String existingDocTemplate) {
+        try {
+            root = new ObjectMapper().readValue(existingDocTemplate, Record.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public ValidateResult validate(String avroSchema) {
+        Schema schema = new Schema.Parser().parse(avroSchema);
+        return validate(schema);
+    }
+
+    public ValidateResult validate(Schema schema) {
+        SchemaBuddy schemaBuddy = SchemaBuddy.parse(schema);
+        Set<String> schemaFieldNames = schemaBuddy.getChildren()
+                .stream()
+                .map(SchemaBuddy::getName)
+                .collect(Collectors.toSet());
+
+        Set<String> templateFieldNames = root.getInstances().stream()
+                .map(Instance::getName)
+                .collect(Collectors.toSet());
+
+        List<String> newSchemaFields = schemaFieldNames.stream()
+                .filter(field -> !templateFieldNames.contains(field))
+                .collect(Collectors.toList());
+
+        List<String> removedSchemaFields = templateFieldNames.stream()
+                .filter(field -> !schemaFieldNames.contains(field))
+                .collect(Collectors.toList());
+
+        return new ValidateResult(newSchemaFields, removedSchemaFields);
+    }
+}

--- a/src/main/java/no/ssb/dapla/dataset/doc/template/ValidateResult.java
+++ b/src/main/java/no/ssb/dapla/dataset/doc/template/ValidateResult.java
@@ -1,0 +1,29 @@
+package no.ssb.dapla.dataset.doc.template;
+
+import java.util.List;
+
+public class ValidateResult {
+    private final List<String> missingTemplateFields;
+    private final List<String> missingSchemaFields;
+
+    public ValidateResult(List<String> missingTemplateFields, List<String> missingSchemaFields) {
+        this.missingTemplateFields = missingTemplateFields;
+        this.missingSchemaFields = missingSchemaFields;
+    }
+
+    public boolean isOk() {
+        return missingSchemaFields.isEmpty() && missingTemplateFields.isEmpty();
+    }
+
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        if (missingTemplateFields.size() > 0) {
+            sb.append("New fields added in spark schema ").append(missingTemplateFields).append(" is not in doc template\n");
+        }
+        if (missingSchemaFields.size() > 0) {
+            sb.append("Fields document in template is no longer in spark schema ").append(missingSchemaFields).append("\n");
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToTemplateTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/SchemaToTemplateTest.java
@@ -229,4 +229,26 @@ class SchemaToTemplateTest {
         Record root = new ObjectMapper().readValue(jsonString, Record.class);
         assertThat(root.getName()).isEmpty();
     }
+
+    @Test
+    void checkValidate() {
+        Schema schema = SchemaBuilder
+                .record("spark_schema").namespace("no.ssb.dataset")
+                .fields()
+                .name("kontonummer").type().stringType().noDefault()
+                .endRecord();
+
+        String template = "{\n" +
+                "  \"name\" : \"\",\n" +
+                "  \"description\" : \"\",\n" +
+                "  \"instanceVariables\" : [ {\n" +
+                "    \"name\" : \"kontonummer\",\n" +
+                "    \"description\" : \"\"\n" +
+                "  } ]\n" +
+                "}\n";
+
+//        System.out.println(new SchemaToTemplate(schema).withDoSimpleFiltering(true).generateSimpleTemplateAsJsonString());
+
+        ValidateResult validateResult = new SchemaToTemplate(schema).validate(template);
+    }
 }

--- a/src/test/java/no/ssb/dapla/dataset/doc/template/TemplateValidatorTest.java
+++ b/src/test/java/no/ssb/dapla/dataset/doc/template/TemplateValidatorTest.java
@@ -1,0 +1,80 @@
+package no.ssb.dapla.dataset.doc.template;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplateValidatorTest {
+
+    @Test
+    void checkValidateOk() {
+        Schema schema = SchemaBuilder
+                .record("spark_schema").namespace("no.ssb.dataset")
+                .fields()
+                .name("kontonummer").type().stringType().noDefault()
+                .endRecord();
+
+        String template = "{\n" +
+                "  \"name\" : \"\",\n" +
+                "  \"description\" : \"\",\n" +
+                "  \"instanceVariables\" : [ {\n" +
+                "    \"name\" : \"kontonummer\",\n" +
+                "    \"description\" : \"\"\n" +
+                "  } ]\n" +
+                "}\n";
+
+        ValidateResult validateResult = new TemplateValidator(template).validate(schema);
+
+        assertThat(validateResult.getMessage()).isEmpty();
+    }
+
+    @Test
+    void checkValidateFieldMissingInTemplate() {
+        Schema schema = SchemaBuilder
+                .record("spark_schema").namespace("no.ssb.dataset")
+                .fields()
+                .name("kontonummer").type().stringType().noDefault()
+                .name("innskudd").type().stringType().noDefault()
+                .endRecord();
+
+        String template = "{\n" +
+                "  \"name\" : \"\",\n" +
+                "  \"description\" : \"\",\n" +
+                "  \"instanceVariables\" : [ {\n" +
+                "    \"name\" : \"kontonummer\",\n" +
+                "    \"description\" : \"\"\n" +
+                "  } ]\n" +
+                "}\n";
+
+        ValidateResult validateResult = new TemplateValidator(template).validate(schema);
+
+        assertThat(validateResult.getMessage()).isEqualTo("New fields added in spark schema [innskudd] is not in doc template\n");
+    }
+
+    @Test
+    void checkValidateFieldMissingInSchema() {
+        Schema schema = SchemaBuilder
+                .record("spark_schema").namespace("no.ssb.dataset")
+                .fields()
+                .name("kontonummer").type().stringType().noDefault()
+                .endRecord();
+
+        String template = "{\n" +
+                "  \"name\" : \"\",\n" +
+                "  \"description\" : \"\",\n" +
+                "  \"instanceVariables\" : [ {\n" +
+                "    \"name\" : \"kontonummer\",\n" +
+                "    \"description\" : \"\"\n" +
+                "  },{" +
+                "    \"name\" : \"innskudd\",\n" +
+                "    \"description\" : \"\"\n" +
+                " }]\n" +
+                "}\n";
+
+        ValidateResult validateResult = new TemplateValidator(template).validate(schema);
+
+        assertThat(validateResult.getMessage()).isEqualTo("Fields document in template is no longer in spark schema [innskudd]\n");
+    }
+}


### PR DESCRIPTION
Validate template against chema.
For now check for missing fields in both schema and doc template.

If this lib is only used from dataset-doc-service I think we could move the code there. @bjornandre?  